### PR TITLE
feature : added cairo mock contracts

### DIFF
--- a/blockchain_assets/contracts/ERC1155Mock.cairo
+++ b/blockchain_assets/contracts/ERC1155Mock.cairo
@@ -1,0 +1,65 @@
+#[starknet::interface]
+pub trait IERC1155Mock<TContractState> {
+    fn mint(ref self: TContractState, owner: starknet::ContractAddress, spender: starknet::ContractAddress, token_id: u256, value: u256);
+}
+
+#[starknet::contract]
+pub mod ERC1155Mock {
+    use starknet::ContractAddress;
+    use openzeppelin::token::erc1155::{ERC1155Component, ERC1155HooksEmptyImpl};
+    use openzeppelin::introspection::src5::SRC5Component;
+
+    component!(path: SRC5Component, storage: src5, event: SRC5Event);
+    component!(path: ERC1155Component, storage: erc1155, event: ERC1155Event);
+
+    #[abi(embed_v0)]
+    impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC1155Impl = ERC1155Component::ERC1155Impl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC1155MetadataURIImpl = ERC1155Component::ERC1155MetadataURIImpl<ContractState>;
+
+    impl SRC5InternalImpl = SRC5Component::InternalImpl<ContractState>;
+    impl ERC1155InternalImpl = ERC1155Component::InternalImpl<ContractState>;
+
+    #[storage]
+    struct Storage {
+        #[substorage(v0)]
+        src5: SRC5Component::Storage,
+        #[substorage(v0)]
+        erc1155: ERC1155Component::Storage
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        #[flat]
+        SRC5Event: SRC5Component::Event,
+        #[flat]
+        ERC1155Event: ERC1155Component::Event
+    }
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState,
+        spender: ContractAddress,
+        initial_id: u256,
+        value: u256,
+        initial_id_two: u256,
+        value_two: u256,
+        initial_owner: ContractAddress
+    ) {
+        self.erc1155.initializer("ERC1155Mock");
+        self.mint(initial_owner, spender, initial_id, value);
+        self.mint(initial_owner, spender, initial_id_two, value_two);
+    }
+
+    #[abi(embed_v0)]
+    impl ERC1155MockImpl of super::IERC1155Mock<ContractState> {
+        fn mint(ref self: ContractState, owner: ContractAddress, spender: ContractAddress, token_id: u256, value: u256) {
+            self.erc1155._set_approval_for_all(owner, spender, true);
+            let data = array![];
+            self.erc1155.mint(owner, token_id, value, data.span());
+        }
+    }
+}

--- a/blockchain_assets/contracts/ERC20Mock.cairo
+++ b/blockchain_assets/contracts/ERC20Mock.cairo
@@ -1,0 +1,66 @@
+#[starknet::interface]
+pub trait IERC20Mock<TContractState> {
+    fn mint(ref self: TContractState, mint_to_: starknet::ContractAddress, spender: starknet::ContractAddress, value_: u256);
+}
+
+#[starknet::contract]
+pub mod ERC20Mock {
+    use starknet::ContractAddress;
+    use openzeppelin::token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+
+    component!(path: ERC20Component, storage: erc20, event: ERC20Event);
+
+    #[abi(embed_v0)]
+    impl ERC20Impl = ERC20Component::ERC20Impl<ContractState>;
+    
+    impl ERC20InternalImpl = ERC20Component::InternalImpl<ContractState>;
+
+    #[storage]
+    struct Storage {
+        #[substorage(v0)]
+        erc20: ERC20Component::Storage
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        #[flat]
+        ERC20Event: ERC20Component::Event
+    }
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState,
+        initial_supply: u256,
+        spender: ContractAddress,
+        initial_owner: ContractAddress,
+        other_client: ContractAddress
+    ) {
+        self.erc20.initializer("ERC20Mock", "E20");
+        let initial_supply_half = initial_supply / 2;
+        
+        ERC20MockImpl::mint(ref self, initial_owner, spender, initial_supply_half);
+        ERC20MockImpl::mint(ref self, other_client, spender, initial_supply_half);
+    }
+    
+    #[abi(embed_v0)]
+    impl ERC20MetadataImpl of openzeppelin::token::erc20::interface::IERC20Metadata<ContractState> {
+        fn name(self: @ContractState) -> ByteArray {
+            "ERC20Mock"
+        }
+        fn symbol(self: @ContractState) -> ByteArray {
+            "E20"
+        }
+        fn decimals(self: @ContractState) -> u8 {
+            9
+        }
+    }
+
+    #[abi(embed_v0)]
+    impl ERC20MockImpl of super::IERC20Mock<ContractState> {
+        fn mint(ref self: ContractState, mint_to_: ContractAddress, spender: ContractAddress, value_: u256) {
+            self.erc20._approve(mint_to_, spender, value_);
+            self.erc20.mint(mint_to_, value_);
+        }
+    }
+}

--- a/blockchain_assets/contracts/ERC3525Mock.cairo
+++ b/blockchain_assets/contracts/ERC3525Mock.cairo
@@ -1,0 +1,97 @@
+#[starknet::interface]
+pub trait IERC3525Mock<TContractState> {
+    fn mint(ref self: TContractState, spender: starknet::ContractAddress, mint_to: starknet::ContractAddress, token_id: u256, slot: u256, value: u256);
+    fn mint_value(ref self: TContractState, token_id: u256, value: u256);
+    fn burn(ref self: TContractState, token_id: u256);
+    fn burn_value(ref self: TContractState, token_id: u256, burn_value: u256);
+    
+    fn owner_of(self: @TContractState, token_id: u256) -> starknet::ContractAddress;
+    fn get_value(self: @TContractState, token_id: u256) -> u256;
+    fn get_slot(self: @TContractState, token_id: u256) -> u256;
+}
+
+#[starknet::contract]
+pub mod ERC3525Mock {
+    use starknet::{ContractAddress, get_caller_address};
+
+    #[storage]
+    struct Storage {
+        owners: LegacyMap<u256, ContractAddress>,
+        values: LegacyMap<u256, u256>,
+        slots: LegacyMap<u256, u256>,
+        operator_approvals: LegacyMap<(ContractAddress, ContractAddress), bool>,
+        token_approvals: LegacyMap<u256, ContractAddress>,
+    }
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState,
+        spender: ContractAddress,
+        initial_id: u256,
+        value: u256,
+        initial_id_two: u256,
+        value_two: u256,
+        slot: u256,
+        initial_owner: ContractAddress
+    ) {
+        self.mint(spender, initial_owner, initial_id, slot, value);
+        self.mint(spender, initial_owner, initial_id_two, slot, value_two);
+    }
+    
+    #[generate_trait]
+    impl InternalImpl of InternalTrait {
+        fn _is_approved_or_owner(self: @ContractState, spender: ContractAddress, token_id: u256) -> bool {
+            let owner = self.owners.read(token_id);
+            if owner == spender {
+                return true;
+            }
+            if self.token_approvals.read(token_id) == spender {
+                return true;
+            }
+            self.operator_approvals.read((owner, spender))
+        }
+    }
+
+    #[abi(embed_v0)]
+    impl ERC3525MockImpl of super::IERC3525Mock<ContractState> {
+        fn mint(ref self: ContractState, spender: ContractAddress, mint_to: ContractAddress, token_id: u256, slot: u256, value: u256) {
+            self.operator_approvals.write((mint_to, spender), true);
+            self.owners.write(token_id, mint_to);
+            self.slots.write(token_id, slot);
+            self.values.write(token_id, value);
+        }
+        
+        fn mint_value(ref self: ContractState, token_id: u256, value: u256) {
+            let current_value = self.values.read(token_id);
+            self.values.write(token_id, current_value + value);
+        }
+        
+        fn burn(ref self: ContractState, token_id: u256) {
+            assert(self._is_approved_or_owner(get_caller_address(), token_id), 'Not approved or owner');
+            
+            self.token_approvals.write(token_id, starknet::contract_address_const::<0>());
+            self.owners.write(token_id, starknet::contract_address_const::<0>());
+            self.values.write(token_id, 0);
+            self.slots.write(token_id, 0);
+        }
+        
+        fn burn_value(ref self: ContractState, token_id: u256, burn_value: u256) {
+            assert(self._is_approved_or_owner(get_caller_address(), token_id), 'Not approved or owner');
+            let current_value = self.values.read(token_id);
+            assert(current_value >= burn_value, 'Insufficient value');
+            self.values.write(token_id, current_value - burn_value);
+        }
+        
+        fn owner_of(self: @ContractState, token_id: u256) -> ContractAddress {
+            self.owners.read(token_id)
+        }
+        
+        fn get_value(self: @ContractState, token_id: u256) -> u256 {
+            self.values.read(token_id)
+        }
+        
+        fn get_slot(self: @ContractState, token_id: u256) -> u256 {
+            self.slots.read(token_id)
+        }
+    }
+}

--- a/blockchain_assets/contracts/ERC721Mock.cairo
+++ b/blockchain_assets/contracts/ERC721Mock.cairo
@@ -1,0 +1,60 @@
+#[starknet::interface]
+pub trait IERC721Mock<TContractState> {
+    fn mint(ref self: TContractState, owner: starknet::ContractAddress, spender: starknet::ContractAddress, token_id: u256);
+}
+
+#[starknet::contract]
+pub mod ERC721Mock {
+    use starknet::ContractAddress;
+    use openzeppelin::token::erc721::{ERC721Component, ERC721HooksEmptyImpl};
+    use openzeppelin::introspection::src5::SRC5Component;
+
+    component!(path: SRC5Component, storage: src5, event: SRC5Event);
+    component!(path: ERC721Component, storage: erc721, event: ERC721Event);
+
+    #[abi(embed_v0)]
+    impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC721Impl = ERC721Component::ERC721Impl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC721MetadataImpl = ERC721Component::ERC721MetadataImpl<ContractState>;
+
+    impl SRC5InternalImpl = SRC5Component::InternalImpl<ContractState>;
+    impl ERC721InternalImpl = ERC721Component::InternalImpl<ContractState>;
+
+    #[storage]
+    struct Storage {
+        #[substorage(v0)]
+        src5: SRC5Component::Storage,
+        #[substorage(v0)]
+        erc721: ERC721Component::Storage
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        #[flat]
+        SRC5Event: SRC5Component::Event,
+        #[flat]
+        ERC721Event: ERC721Component::Event
+    }
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState,
+        initial_id: u256,
+        initial_owner: ContractAddress,
+        spender: ContractAddress
+    ) {
+        self.erc721.initializer("ERC721Mock", "E721", "");
+        ERC721MockImpl::mint(ref self, initial_owner, spender, initial_id);
+    }
+
+    #[abi(embed_v0)]
+    impl ERC721MockImpl of super::IERC721Mock<ContractState> {
+        fn mint(ref self: ContractState, owner: ContractAddress, spender: ContractAddress, token_id: u256) {
+            self.erc721._set_approval_for_all(owner, spender, true);
+            self.erc721._mint(owner, token_id);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- added contracts for ERC20, ERC721, ERC1155, ERC3525 in cairo
- resolves isssue #4

## Checklist
- [ ] Tests added/updated
- [ ] CI passes
- [x] No secrets/keys committed
- [x] Docs updated (if needed)
- [x] Backwards compatible (or noted breaking change)
